### PR TITLE
Make WithSort arg field names public

### DIFF
--- a/get-records.go
+++ b/get-records.go
@@ -42,12 +42,12 @@ func (grc *GetRecordsConfig) WithFilterFormula(filterFormula string) *GetRecords
 
 // WithSort add sorting to request.
 func (grc *GetRecordsConfig) WithSort(sortQueries ...struct {
-	fieldName string
-	direction string
+	FieldName string
+	Direction string
 }) *GetRecordsConfig {
 	for queryNum, sortQuery := range sortQueries {
-		grc.params.Set(fmt.Sprintf("sort[%v][field]", queryNum), sortQuery.fieldName)
-		grc.params.Set(fmt.Sprintf("sort[%v][direction]", queryNum), sortQuery.direction)
+		grc.params.Set(fmt.Sprintf("sort[%v][field]", queryNum), sortQuery.FieldName)
+		grc.params.Set(fmt.Sprintf("sort[%v][direction]", queryNum), sortQuery.Direction)
 	}
 	return grc
 }

--- a/get-records_test.go
+++ b/get-records_test.go
@@ -13,12 +13,12 @@ func TestGetRecordsConfig_Do(t *testing.T) {
 	table := testTable(t)
 	table.client.baseURL = mockResponse("get_records_with_filter.json").URL
 	sortQuery1 := struct {
-		fieldName string
-		direction string
+		FieldName string
+		Direction string
 	}{"Field1", "desc"}
 	sortQuery2 := struct {
-		fieldName string
-		direction string
+		FieldName string
+		Direction string
 	}{"Field2", "asc"}
 
 	records, err := table.GetRecords().


### PR DESCRIPTION
Field names on the anonymous struct for WithSort should be public. Otherwise callers in other packages cannot assign to the private fields and calling WithSort results in errors like this:

```
cannot use sortQuery (variable of type struct{fieldName string; direction string}) as struct{fieldName string; direction string} value in argument to config.WithSort (IncompatibleAssign)
```