### PR TITLE
Adding options field to Field struct

### DIFF
--- a/base.go
+++ b/base.go
@@ -23,6 +23,7 @@ type Field struct {
 	Type        string `json:"type"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Options     map[string]interface{} `json:"options"`
 }
 
 type View struct {


### PR DESCRIPTION
Closes https://github.com/mehanizm/airtable/issues/17

I just add the Options field to Field struct. I don't know if the type `map[string]interface{}` is best suited. I am a noob in GoLang and don't know any best practices but it worked.

Let me know if you need anything