### PR TITLE
expose raw response for advanced use cases

### DIFF
--- a/base.go
+++ b/base.go
@@ -56,7 +56,7 @@ func (at *Client) GetBasesWithParams(params url.Values) (*Bases, error) {
 func (at *Client) GetBasesWithParamsContext(ctx context.Context, params url.Values) (*Bases, error) {
 	bases := new(Bases)
 
-	err := at.get(ctx, "meta", "bases", "", params, bases)
+	_, err := at.get(ctx, "meta", "bases", "", params, bases)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (b *BaseConfig) GetTables() (*Tables, error) {
 func (b *BaseConfig) GetTablesContext(ctx context.Context) (*Tables, error) {
 	tables := new(Tables)
 
-	err := b.client.get(ctx, "meta/bases", b.dbId, "tables", nil, tables)
+	_, err := b.client.get(ctx, "meta/bases", b.dbId, "tables", nil, tables)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -26,12 +26,12 @@ func TestClient_do(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = c.do(req, nil)
+	_, err = c.do(req, nil)
 	var e *HTTPClientError
 	if errors.Is(err, e) {
 		t.Errorf("should be an http error, but was not: %v", err)
 	}
-	err = c.do(nil, nil)
+	_, err = c.do(nil, nil)
 	if err == nil {
 		t.Errorf("there should be an error, but was nil")
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mehanizm/airtable
+module github.com/tkellen/airtable
 
 go 1.20

--- a/record.go
+++ b/record.go
@@ -37,11 +37,10 @@ func (t *Table) GetRecord(recordID string) (*Record, error) {
 func (t *Table) GetRecordContext(ctx context.Context, recordID string) (*Record, error) {
 	result := new(Record)
 
-	err := t.client.get(ctx, t.dbName, t.tableName, recordID, url.Values{}, result)
+	_, err := t.client.get(ctx, t.dbName, t.tableName, recordID, url.Values{}, result)
 	if err != nil {
 		return nil, err
 	}
-
 	result.client = t.client
 	result.table = t
 
@@ -66,13 +65,12 @@ func (r *Record) UpdateRecordPartialContext(ctx context.Context, changedFields m
 	}
 	response := new(Records)
 
-	err := r.client.patch(ctx, r.table.dbName, r.table.tableName, data, response)
+	_, err := r.client.patch(ctx, r.table.dbName, r.table.tableName, data, response)
 	if err != nil {
 		return nil, err
 	}
 
 	result := response.Records[0]
-
 	result.client = r.client
 	result.table = r.table
 
@@ -89,7 +87,7 @@ func (r *Record) DeleteRecord() (*Record, error) {
 func (r *Record) DeleteRecordContext(ctx context.Context) (*Record, error) {
 	response := new(Records)
 
-	err := r.client.delete(ctx, r.table.dbName, r.table.tableName, []string{r.ID}, response)
+	_, err := r.client.delete(ctx, r.table.dbName, r.table.tableName, []string{r.ID}, response)
 	if err != nil {
 		return nil, err
 	}

--- a/table.go
+++ b/table.go
@@ -12,8 +12,9 @@ import (
 
 // Records base type of airtable records.
 type Records struct {
-	Records []*Record `json:"records"`
-	Offset  string    `json:"offset,omitempty"`
+	Records     []*Record `json:"records"`
+	ResponseRaw []byte
+	Offset      string `json:"offset,omitempty"`
 
 	// The Airtable API will perform best-effort automatic data conversion
 	// from string values if the typecast parameter is passed in.
@@ -49,10 +50,11 @@ func (t *Table) GetRecordsWithParams(params url.Values) (*Records, error) {
 func (t *Table) GetRecordsWithParamsContext(ctx context.Context, params url.Values) (*Records, error) {
 	records := new(Records)
 
-	err := t.client.get(ctx, t.dbName, t.tableName, "", params, records)
+	raw, err := t.client.get(ctx, t.dbName, t.tableName, "", params, records)
 	if err != nil {
 		return nil, err
 	}
+	records.ResponseRaw = raw
 
 	for _, record := range records.Records {
 		record.client = t.client
@@ -73,10 +75,11 @@ func (t *Table) AddRecords(records *Records) (*Records, error) {
 func (t *Table) AddRecordsContext(ctx context.Context, records *Records) (*Records, error) {
 	result := new(Records)
 
-	err := t.client.post(ctx, t.dbName, t.tableName, records, result)
+	raw, err := t.client.post(ctx, t.dbName, t.tableName, records, result)
 	if err != nil {
 		return nil, err
 	}
+	result.ResponseRaw = raw
 
 	for _, record := range result.Records {
 		record.client = t.client
@@ -95,10 +98,11 @@ func (t *Table) UpdateRecords(records *Records) (*Records, error) {
 func (t *Table) UpdateRecordsContext(ctx context.Context, records *Records) (*Records, error) {
 	response := new(Records)
 
-	err := t.client.put(ctx, t.dbName, t.tableName, records, response)
+	raw, err := t.client.put(ctx, t.dbName, t.tableName, records, response)
 	if err != nil {
 		return nil, err
 	}
+	response.ResponseRaw = raw
 
 	for _, record := range response.Records {
 		record.client = t.client
@@ -117,10 +121,11 @@ func (t *Table) UpdateRecordsPartial(records *Records) (*Records, error) {
 func (t *Table) UpdateRecordsPartialContext(ctx context.Context, records *Records) (*Records, error) {
 	response := new(Records)
 
-	err := t.client.patch(ctx, t.dbName, t.tableName, records, response)
+	raw, err := t.client.patch(ctx, t.dbName, t.tableName, records, response)
 	if err != nil {
 		return nil, err
 	}
+	response.ResponseRaw = raw
 
 	for _, record := range response.Records {
 		record.client = t.client
@@ -141,10 +146,11 @@ func (t *Table) DeleteRecords(recordIDs []string) (*Records, error) {
 func (t *Table) DeleteRecordsContext(ctx context.Context, recordIDs []string) (*Records, error) {
 	response := new(Records)
 
-	err := t.client.delete(ctx, t.dbName, t.tableName, recordIDs, response)
+	raw, err := t.client.delete(ctx, t.dbName, t.tableName, recordIDs, response)
 	if err != nil {
 		return nil, err
 	}
+	response.ResponseRaw = raw
 
 	for _, record := range response.Records {
 		record.client = t.client


### PR DESCRIPTION
I have a use case where a client would like to generate a form based on fields in a table. The ordering of the columns in the table is relevant to the representation of the form. It is possible to retain the ordering of keys in a json response using `github.com/tidwall/gjson` but it requires access to the raw json response. I don't love this implementation but it was the cleanest way I could find to lift the raw response body into the public API. Would you consider this change? If so I would be happy to make any modifications you'd like to see.