### PR TITLE
Added support for Upload Attachment API

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -1,0 +1,46 @@
+package airtable
+
+import "context"
+
+type Attachment struct {
+	ContentType string `json:"contentType"`
+	File        string `json:"file"`
+	FileName    string `json:"filename"`
+}
+
+type FieldAttachments struct {
+	client *Client
+	table  *Table
+	// Parent record's ID of the attached file.
+	Id          string `json:"id"`
+	CreatedTime string `json:"createdTime"`
+	// Mapped array of attachments attached to this field.
+	//
+	// Key is the ID of the record's attachment field and the value is the list of attached files.
+	Attachments map[string][]FieldAttachmentDetails `json:"fields"`
+}
+
+type FieldAttachmentDetails struct {
+	// Airtable's attachment ID
+	Id       string `json:"id"`
+	URL      string `json:"url"`
+	FileName string `json:"filename"`
+	// In bytes
+	Size int `json:"size"`
+	// Content-Type value
+	Type string `json:"type"`
+}
+
+func (t *Table) UploadAttachment(ctx context.Context, recordID string, attachmentFieldIdOrName string, data Attachment) (*FieldAttachments, error) {
+	result := new(FieldAttachments)
+
+	err := t.client.postAttachment(ctx, t.dbName, recordID, attachmentFieldIdOrName, data, result)
+	if err != nil {
+		return nil, err
+	}
+
+	result.client = t.client
+	result.table = t
+
+	return result, nil
+}

--- a/attachment.go
+++ b/attachment.go
@@ -31,7 +31,10 @@ type FieldAttachmentDetails struct {
 	Type string `json:"type"`
 }
 
-func (t *Table) UploadAttachment(ctx context.Context, recordID string, attachmentFieldIdOrName string, data Attachment) (*FieldAttachments, error) {
+func (t *Table) UploadAttachment(recordID string, attachmentFieldIdOrName string, data Attachment) (*FieldAttachments, error) {
+	return t.UploadAttachmentContext(context.Background(), recordID, attachmentFieldIdOrName, data)
+}
+func (t *Table) UploadAttachmentContext(ctx context.Context, recordID string, attachmentFieldIdOrName string, data Attachment) (*FieldAttachments, error) {
 	result := new(FieldAttachments)
 
 	err := t.client.postAttachment(ctx, t.dbName, recordID, attachmentFieldIdOrName, data, result)

--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	airtableBaseURL                 = "https://api.airtable.com/v0"
-	airtableUploadAttachmentBaseURL = "https://content.airtable.com/v0/"
+	airtableUploadAttachmentBaseURL = "https://content.airtable.com/v0"
 	rateLimit                       = 4
 )
 

--- a/client.go
+++ b/client.go
@@ -18,16 +18,18 @@ import (
 )
 
 const (
-	airtableBaseURL = "https://api.airtable.com/v0"
-	rateLimit       = 4
+	airtableBaseURL                 = "https://api.airtable.com/v0"
+	airtableUploadAttachmentBaseURL = "https://content.airtable.com/v0/"
+	rateLimit                       = 4
 )
 
 // Client client for airtable api.
 type Client struct {
-	client      *http.Client
-	rateLimiter <-chan time.Time
-	baseURL     string
-	apiKey      string
+	client                  *http.Client
+	rateLimiter             <-chan time.Time
+	baseURL                 string
+	uploadAttachmentBaseURL string
+	apiKey                  string
 }
 
 // NewClient airtable client constructor
@@ -35,10 +37,11 @@ type Client struct {
 // https://airtable.com/account
 func NewClient(apiKey string) *Client {
 	return &Client{
-		client:      http.DefaultClient,
-		rateLimiter: time.Tick(time.Second / time.Duration(rateLimit)),
-		apiKey:      apiKey,
-		baseURL:     airtableBaseURL,
+		client:                  http.DefaultClient,
+		rateLimiter:             time.Tick(time.Second / time.Duration(rateLimit)),
+		apiKey:                  apiKey,
+		baseURL:                 airtableBaseURL,
+		uploadAttachmentBaseURL: airtableUploadAttachmentBaseURL,
 	}
 }
 
@@ -107,6 +110,27 @@ func (at *Client) post(ctx context.Context, db, table string, data, response any
 	at.rateLimit()
 
 	url := fmt.Sprintf("%s/%s/%s", at.baseURL, db, table)
+
+	body, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("cannot marshal body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("cannot create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", at.apiKey))
+
+	return at.do(req, response)
+}
+
+func (at *Client) postAttachment(ctx context.Context, db, recordID string, attachmentFieldIdOrName string, data Attachment, response any) error {
+	at.rateLimit()
+
+	url := fmt.Sprintf("%s/%s/%s/%s/uploadAttachment", at.uploadAttachmentBaseURL, db, recordID, attachmentFieldIdOrName)
 
 	body, err := json.Marshal(data)
 	if err != nil {


### PR DESCRIPTION
As the title says, I added a new method to upload attachments using [Airtable's attachments API](https://airtable.com/developers/web/api/upload-attachment).

I tried to keep as close as the rest of the package's code style, but there might be room for improvement. I'm open to making any changes to make it acceptable.

I did not write any unit tests. If it's needed, I will do it without any problem.