### PR TITLE
Add option to get the record fields by ID

### DIFF
--- a/get-records.go
+++ b/get-records.go
@@ -103,6 +103,12 @@ func (grc *GetRecordsConfig) InStringFormat(timeZone, userLocale string) *GetRec
 	return grc
 }
 
+// WithFieldsById returns the Record fields by field ID instead of names.
+func (grc *GetRecordsConfig) WithFieldsById() *GetRecordsConfig {
+	grc.params.Set("returnFieldsByFieldId", "true")
+	return grc
+}
+
 // Do send the prepared get records request.
 func (grc *GetRecordsConfig) Do() (*Records, error) {
 	return grc.table.GetRecordsWithParams(grc.params)

--- a/get-records_test.go
+++ b/get-records_test.go
@@ -25,6 +25,7 @@ func TestGetRecordsConfig_Do(t *testing.T) {
 		FromView("view_1").
 		WithFilterFormula("AND({Field1}='value_1',NOT({Field2}='value_2'))").
 		WithSort(sortQuery1, sortQuery2).
+		WithFieldsById().
 		ReturnFields("Field1", "Field2").
 		InStringFormat("Europe/Moscow", "ru").
 		MaxRecords(100).


### PR DESCRIPTION
Allow getting the field ID's instead of names in the records.

see https://airtable.com/developers/web/api/get-record#query-returnfieldsbyfieldid