### PR TITLE
feat: Request retry for 429 and 503 responses with exponential backoff

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,8 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -31,6 +33,7 @@ var (
 	backoffMaxRetries = 3
 	backoffBaseDelay  = 100 * time.Millisecond
 	backoffMaxJitter  = 100 * time.Millisecond
+	backoffMaxDelay   = 2 * time.Second
 )
 
 // Client client for airtable api.
@@ -41,9 +44,10 @@ type Client struct {
 	uploadAttachmentBaseURL string
 	apiKey                  string
 	// backoff parameters (per-client)
-	maxRetries    int
-	backoffBase   time.Duration
-	backoffJitter time.Duration
+	maxRetries      int
+	backoffBase     time.Duration
+	backoffJitter   time.Duration
+	backoffMaxDelay time.Duration
 }
 
 // NewClient airtable client constructor
@@ -59,6 +63,7 @@ func NewClient(apiKey string) *Client {
 		maxRetries:              backoffMaxRetries,
 		backoffBase:             backoffBaseDelay,
 		backoffJitter:           backoffMaxJitter,
+		backoffMaxDelay:         backoffMaxDelay,
 	}
 }
 
@@ -75,6 +80,12 @@ func (at *Client) SetBackoffBaseDelay(d time.Duration) {
 // SetBackoffMaxJitter sets the maximum jitter added to backoff sleeps.
 func (at *Client) SetBackoffMaxJitter(d time.Duration) {
 	at.backoffJitter = d
+}
+
+// SetBackoffMaxDelay sets the maximum delay (cap) for exponential backoff.
+// If set to 0, backoff delay will be uncapped
+func (at *Client) SetBackoffMaxDelay(d time.Duration) {
+	at.backoffMaxDelay = d
 }
 
 // Set custom http client for custom usage
@@ -290,9 +301,10 @@ func (at *Client) do(req *http.Request, response any) error {
 		}
 	}
 
-	// Attempt requests with retries on 503. On non-503 non-2xx responses we
-	// return immediately. On 503 we retry with exponential backoff + jitter.
-	for attempt := 0; attempt <= backoffMaxRetries; attempt++ {
+	// Attempt requests with retries on 503 and 429. On non-retryable
+	// non-2xx responses we return immediately. On retryable responses we
+	// retry with exponential backoff + jitter, capped by backoffMaxDelay.
+	for attempt := 0; attempt <= at.maxRetries; attempt++ {
 		creq := req.Clone(req.Context())
 		if req.GetBody != nil {
 			rc, err := req.GetBody()
@@ -306,24 +318,48 @@ func (at *Client) do(req *http.Request, response any) error {
 		if err != nil {
 			return fmt.Errorf("HTTP request failure on %s: %w", url, err)
 		}
-
-		// If it's a 503 and we still have retries left, drain and close the
-		// body then sleep and retry. If this is the final attempt, let
-		// makeHTTPClientError read the body (don't close it here).
-		if resp.StatusCode == http.StatusServiceUnavailable {
-			if attempt == backoffMaxRetries {
+		// If it's a retryable status (503 or 429), handle retries.
+		if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusTooManyRequests {
+			if attempt == at.maxRetries {
 				// final attempt, return error; do not close body so the
 				// error helper can read it.
 				return makeHTTPClientError(url, resp)
+			}
+
+			// Determine sleep duration: prefer Retry-After header if present.
+			var sleep time.Duration
+			if ra := resp.Header.Get("Retry-After"); ra != "" {
+				// try parse as integer seconds
+				if secs, err := strconv.Atoi(strings.TrimSpace(ra)); err == nil {
+					sleep = time.Duration(secs) * time.Second
+				} else if t, err := http.ParseTime(ra); err == nil {
+					sleep = time.Until(t)
+					if sleep < 0 {
+						sleep = 0
+					}
+				}
+			}
+
+			// If no Retry-After, use exponential backoff
+			if sleep == 0 {
+				sleep = at.backoffBase * time.Duration(1<<attempt)
+			}
+
+			// clip to max delay
+			if at.backoffMaxDelay > 0 && sleep > at.backoffMaxDelay {
+				sleep = at.backoffMaxDelay
 			}
 
 			// drain and close so idle connection can be reused
 			io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 
-			// exponential backoff with jitter
-			sleep := backoffBaseDelay * time.Duration(1<<attempt)
-			jitter := time.Duration(rand.Int63n(int64(backoffMaxJitter)))
+			// add jitter
+			var jitter time.Duration
+			if at.backoffJitter > 0 {
+				jitter = time.Duration(rand.Int63n(int64(at.backoffJitter)))
+			}
+
 			time.Sleep(sleep + jitter)
 
 			// try again

--- a/client.go
+++ b/client.go
@@ -12,8 +12,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
+	"time"
 
 	"golang.org/x/time/rate"
 )
@@ -24,6 +26,13 @@ const (
 	rateLimit                       = 4
 )
 
+var (
+	// backoff settings for retrying 503 responses
+	backoffMaxRetries = 3
+	backoffBaseDelay  = 100 * time.Millisecond
+	backoffMaxJitter  = 100 * time.Millisecond
+)
+
 // Client client for airtable api.
 type Client struct {
 	client                  *http.Client
@@ -31,6 +40,10 @@ type Client struct {
 	baseURL                 string
 	uploadAttachmentBaseURL string
 	apiKey                  string
+	// backoff parameters (per-client)
+	maxRetries    int
+	backoffBase   time.Duration
+	backoffJitter time.Duration
 }
 
 // NewClient airtable client constructor
@@ -43,7 +56,25 @@ func NewClient(apiKey string) *Client {
 		apiKey:                  apiKey,
 		baseURL:                 airtableBaseURL,
 		uploadAttachmentBaseURL: airtableUploadAttachmentBaseURL,
+		maxRetries:              backoffMaxRetries,
+		backoffBase:             backoffBaseDelay,
+		backoffJitter:           backoffMaxJitter,
 	}
+}
+
+// SetBackoffRetries sets how many retries will be attempted on 503 responses.
+func (at *Client) SetBackoffRetries(n int) {
+	at.maxRetries = n
+}
+
+// SetBackoffBaseDelay sets the base delay used for exponential backoff.
+func (at *Client) SetBackoffBaseDelay(d time.Duration) {
+	at.backoffBase = d
+}
+
+// SetBackoffMaxJitter sets the maximum jitter added to backoff sleeps.
+func (at *Client) SetBackoffMaxJitter(d time.Duration) {
+	at.backoffJitter = d
 }
 
 // Set custom http client for custom usage
@@ -244,26 +275,81 @@ func (at *Client) do(req *http.Request, response any) error {
 
 	url := req.URL.RequestURI()
 
-	resp, err := at.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("HTTP request failure on %s: %w", url, err)
+	// Ensure request body can be replayed for retries. If GetBody is not
+	// provided, read the body and set GetBody so we can recreate Body for
+	// each attempt.
+	if req.Body != nil && req.GetBody == nil {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return fmt.Errorf("reading request body before retrying: %w", err)
+		}
+		// reset original Body
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+		}
 	}
 
-	defer resp.Body.Close()
+	// Attempt requests with retries on 503. On non-503 non-2xx responses we
+	// return immediately. On 503 we retry with exponential backoff + jitter.
+	for attempt := 0; attempt <= backoffMaxRetries; attempt++ {
+		creq := req.Clone(req.Context())
+		if req.GetBody != nil {
+			rc, err := req.GetBody()
+			if err != nil {
+				return fmt.Errorf("failed to get request body for retry: %w", err)
+			}
+			creq.Body = rc
+		}
 
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return makeHTTPClientError(url, resp)
+		resp, err := at.client.Do(creq)
+		if err != nil {
+			return fmt.Errorf("HTTP request failure on %s: %w", url, err)
+		}
+
+		// If it's a 503 and we still have retries left, drain and close the
+		// body then sleep and retry. If this is the final attempt, let
+		// makeHTTPClientError read the body (don't close it here).
+		if resp.StatusCode == http.StatusServiceUnavailable {
+			if attempt == backoffMaxRetries {
+				// final attempt, return error; do not close body so the
+				// error helper can read it.
+				return makeHTTPClientError(url, resp)
+			}
+
+			// drain and close so idle connection can be reused
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+
+			// exponential backoff with jitter
+			sleep := backoffBaseDelay * time.Duration(1<<attempt)
+			jitter := time.Duration(rand.Int63n(int64(backoffMaxJitter)))
+			time.Sleep(sleep + jitter)
+
+			// try again
+			continue
+		}
+
+		// Non-2xx responses (other than 503 handled above)
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			return makeHTTPClientError(url, resp)
+		}
+
+		// Success path: read the body, close, and unmarshal
+		b, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return fmt.Errorf("HTTP Read error on response for %s: %w", url, err)
+		}
+
+		err = json.Unmarshal(b, response)
+		if err != nil {
+			return fmt.Errorf("JSON decode failed on %s:\n%s\nerror: %w", url, string(b), err)
+		}
+
+		return nil
 	}
 
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("HTTP Read error on response for %s: %w", url, err)
-	}
-
-	err = json.Unmarshal(b, response)
-	if err != nil {
-		return fmt.Errorf("JSON decode failed on %s:\n%s\nerror: %w", url, string(b), err)
-	}
-
-	return nil
+	// Should never reach here
+	return errors.New("request retry loop exhausted")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -34,6 +35,61 @@ func TestClient_do(t *testing.T) {
 	err = c.do(nil, nil)
 	if err == nil {
 		t.Errorf("there should be an error, but was nil")
+	}
+}
+
+func TestClient_do_retriesOn503_success(t *testing.T) {
+	c := testClient()
+	// server returns 503 twice, then 200 with JSON
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls < 2 {
+			calls++
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]any
+	if err := c.do(req, &out); err != nil {
+		t.Fatalf("expected success after retries, got err: %v", err)
+	}
+
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true in response, got: %#v", out)
+	}
+}
+
+func TestClient_do_retriesOn503_exhaust(t *testing.T) {
+	c := testClient()
+	// server always returns 503
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.do(req, nil)
+	var httpErr *HTTPClientError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPClientError, got: %v", err)
+	}
+
+	if httpErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got: %d", httpErr.StatusCode)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -93,6 +93,37 @@ func TestClient_do_retriesOn503_exhaust(t *testing.T) {
 	}
 }
 
+func TestClient_do_retriesOn429_success(t *testing.T) {
+	c := testClient()
+	// server returns 429 twice, then 200 with JSON
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls < 2 {
+			calls++
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest("GET", srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out map[string]any
+	if err := c.do(req, &out); err != nil {
+		t.Fatalf("expected success after retries on 429, got err: %v", err)
+	}
+
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true in response, got: %#v", out)
+	}
+}
+
 func TestClient_SetBaseURL(t *testing.T) {
 	testCases := []struct {
 		description   string

--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,8 @@ func makeHTTPClientError(url string, resp *http.Response) error {
 		respStatusText = "Too Large The request exceeded the maximum allowed payload size. You shouldn't encounter this under normal use."
 	case 422:
 		respStatusText = "The request data is invalid. This includes most of the base-specific validations. You will receive a detailed error message and code pointing to the exact issue."
+	case 429:
+		respStatusText = "Request rate limit reached. You should retry the request with backoffs."
 	case 500:
 		respStatusText = "Error The server encountered an unexpected condition."
 	case 502:


### PR DESCRIPTION
## Description

This PR adds automatic request retry with backoff for retryable responses (429 and 503) and customizable parameters.

## Changes

Rewrote Client.do to:

- Ensure request bodies are replayable (set GetBody when missing).
- Retry up to `Client.maxRetries` times on HTTP 429 and 503 with exponential backoff and jitter.
- Drain and close response bodies for intermediate 429/503 responses so connections can be reused.
- Leave the final 429/503 response body intact so `makeHTTPClientError` can read it.

#### Notes and rationale
- I preserved behavior for non-retryable non-2xx responses by returning `makeHTTPClientError` immediately.
- For requests with bodies, I set `req.GetBody` so each attempt can get a fresh Body reader. This matches how `http` expects retryable requests to behave.
- Kept default backoff values conservative (base 100ms, 3 retries). These can be tuned or made configurable if user wants.
- I avoided closing the response in the final failed attempt so `makeHTTPClientError` can read the body (it calls `io.ReadAll`).